### PR TITLE
Rename to meyer_reset to match bower package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-  "name": "meyer-reset",
+  "name": "meyer_reset",
   "version": "2.0.20110126.0"
 }


### PR DESCRIPTION
Turns out we need the same name as the Bower package during the transition period :(
